### PR TITLE
Apply other text to non-link schedule types

### DIFF
--- a/web/src/repo/RoleplayProjectSidebar.tsx
+++ b/web/src/repo/RoleplayProjectSidebar.tsx
@@ -463,7 +463,7 @@ export const RoleplayProjectSidebar = (props: RoleplayProjectSidebarProps) => {
 
               {(schedule || isEditing) && (
                 <ScheduleDisplay
-                  enablePreview
+                  enablePreview={isEditing}
                   schedule={schedule}
                   isEditing={isEditing}
                   setSchedule={(schedule) =>

--- a/web/src/repo/RoleplayProjectSidebar.tsx
+++ b/web/src/repo/RoleplayProjectSidebar.tsx
@@ -36,7 +36,6 @@ import {
   RoleplayLink,
   RoleplayProject,
 } from '../model/RoleplayProject';
-import { ScheduleRegion, ScheduleType } from '../model/RoleplayScheduling';
 import { queryServer } from '../model/ServerResponse';
 import { User, UserRole } from '../model/User';
 
@@ -464,6 +463,7 @@ export const RoleplayProjectSidebar = (props: RoleplayProjectSidebarProps) => {
 
               {(schedule || isEditing) && (
                 <ScheduleDisplay
+                  enablePreview
                   schedule={schedule}
                   isEditing={isEditing}
                   setSchedule={(schedule) =>


### PR DESCRIPTION
Provides `otherText` for additional context on non-link schedules, with a preview button in edit mode to see how it renders in text. Resolves #13 

In card:
![image](https://github.com/user-attachments/assets/2806d138-d2e4-402d-84ae-8f1d61816b4a)

In page: 
![image](https://github.com/user-attachments/assets/7c5cd2dd-bdbd-47d4-a896-f2d65b470516)


In edit view:
![image](https://github.com/user-attachments/assets/567e87cf-4c27-4c39-bfef-fa86023f36b1)
