### PR TITLE
Feature/timeline controls

### DIFF
--- a/web/src/repo/RepoTimeline.css
+++ b/web/src/repo/RepoTimeline.css
@@ -80,3 +80,78 @@
   grid-template-columns: subgrid;
   pointer-events: none;
 }
+
+#timeline-controls {
+  --timeline-button-color: #d26262;
+  --timeline-button-background-color: #333;
+  position: absolute;
+  bottom: 48px;
+  right: 48px;
+  gap: 24px;
+  align-items: flex-end;
+  z-index: 10;
+}
+
+#timeline-controls button.timeline-control {
+  color: var(--timeline-button-color);
+  background-color: var(--timeline-button-background-color);
+  box-shadow: var(--mui-shadows-6);
+  transition: filter 0.1s;
+}
+
+#timeline-controls button.timeline-control:hover {
+  filter: brightness(110%);
+}
+
+#timeline-controls button.timeline-control:active {
+  filter: brightness(90%);
+}
+
+#timeline-controls .MuiDateCalendar-root {
+  background-color: var(--timeline-button-background-color);
+  border-radius: 16px;
+}
+
+#timeline-controls .MuiDateCalendar-root .MuiButtonBase-root.Mui-selected {
+  background-color: var(--timeline-button-color);
+}
+
+#timeline-controls
+  .MuiDateCalendar-root
+  .MuiButtonBase-root:not(.Mui-selected):hover {
+  background-color: #cf666620;
+}
+
+#timeline-controls #military-time-toggle button {
+  width: 56px;
+}
+
+#timeline-controls
+  #military-time-toggle
+  .MuiButtonBase-root:not(.Mui-selected) {
+  background-color: var(--mui-palette-background-dark);
+}
+
+#hour-width-slider-container {
+  display: flex;
+  border-radius: 24px;
+  background-color: var(--timeline-button-background-color);
+  padding: 0 12px;
+}
+
+#hour-width-slider {
+  width: 200px;
+  height: 12px;
+  color: var(--timeline-button-color);
+}
+
+span.MuiSlider-thumb:focus,
+span.MuiSlider-thumb:hover,
+span.MuiSlider-thumb.Mui-active,
+span.MuiSlider-thumb.Mui-focusVisible {
+  box-shadow: inherit;
+}
+
+span.MuiSlider-thumb::before {
+  display: none;
+}

--- a/web/src/repo/RepoTimeline.css
+++ b/web/src/repo/RepoTimeline.css
@@ -83,7 +83,7 @@
 
 #timeline-controls {
   --timeline-button-color: #d26262;
-  --timeline-button-background-color: #333;
+  --timeline-button-background-color: #303030;
   position: absolute;
   bottom: 48px;
   right: 48px;
@@ -124,6 +124,10 @@
 
 #timeline-controls #military-time-toggle button {
   width: 56px;
+}
+
+#timeline-controls #military-time-toggle button.Mui-selected:hover {
+  filter: none;
 }
 
 #timeline-controls

--- a/web/src/repo/RepoTimeline.tsx
+++ b/web/src/repo/RepoTimeline.tsx
@@ -48,7 +48,6 @@ export const RepoTimeline = (props: RepoTimelineProps) => {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [totalStartDate, setTotalStartDate] = useState(initialStartDate);
   const [totalEndDate, setTotalEndDate] = useState(initialEndDate);
-  const [timelineNode, setTimelineNode] = useState<HTMLDivElement | null>();
   const {
     data: pageData,
     error,
@@ -109,7 +108,7 @@ export const RepoTimeline = (props: RepoTimelineProps) => {
     ((date.getTime() - totalStartDate.getTime()) / (1000 * 60 * 60)) *
     PIXELS_PER_HOUR;
 
-  const { ref: dragRef } = useDragScroll({
+  const { ref: dragRef, node: timelineNode } = useDragScroll({
     onDragEnd: (node) => {
       if (!node) {
         return;
@@ -124,6 +123,7 @@ export const RepoTimeline = (props: RepoTimelineProps) => {
       );
       setTimeQuery(newDate);
     },
+    onOffsetNode: () => setCurrentDate(new Date()),
   });
   const infiniteScrollRef: InfiniteScrollRef<HTMLDivElement> =
     useInfiniteScroll({
@@ -177,7 +177,7 @@ export const RepoTimeline = (props: RepoTimelineProps) => {
   }));
 
   const left = timelineNode
-    ? timelineNode.scrollLeft - timelineNode.clientWidth
+    ? timelineNode.scrollLeft + timelineNode.clientWidth
     : 0;
   const right = timelineNode ? left + 3 * timelineNode.clientWidth : 0;
   const leftDate = timelineNode
@@ -210,7 +210,6 @@ export const RepoTimeline = (props: RepoTimelineProps) => {
     <div
       id='repo-timeline-component'
       ref={(node) => {
-        setTimelineNode(node);
         infiniteScrollRef.current = node;
         dragRef(node);
       }}

--- a/web/src/repo/RepoTimeline.tsx
+++ b/web/src/repo/RepoTimeline.tsx
@@ -234,7 +234,7 @@ export const RepoTimeline = (props: RepoTimelineProps) => {
     if (!timelineContainsDate(date)) {
       setTimeout(() => navigate(0), 500);
     } else {
-      setTimeout(() => setCurrentDate(new Date()), 500);
+      setTimeout(() => setCurrentDate(new Date()), 1000);
     }
     timelineNode?.scrollTo({
       behavior: 'smooth',

--- a/web/src/repo/RepoTimeline.tsx
+++ b/web/src/repo/RepoTimeline.tsx
@@ -384,34 +384,39 @@ export const RepoTimeline = (props: RepoTimelineProps) => {
           size='small'
           value={useMilitaryTime}
           onChange={(_, newUseMilitaryTime) => {
-            setUseMilitaryTime(newUseMilitaryTime);
+            if (newUseMilitaryTime !== null) {
+              setUseMilitaryTime(newUseMilitaryTime);
+            }
           }}
           aria-label='view-toggle'
         >
-          <ToggleButton className='timeline-control' value={false}>
-            12AM
-          </ToggleButton>
-          <ToggleButton className='timeline-control' value={true}>
-            00:00
-          </ToggleButton>
-        </ToggleButtonGroup>
-        {/* <Tooltip
-          title='Column width'
-          placement='top'
-          slotProps={{
-            tooltip: {
-              style: { marginBottom: 4 },
-            },
-          }}
-        >
-          <IconButton
-            className='timeline-control'
-            style={{ borderRadius: 8 }}
-            onClick={() => setShowColumnWidthSlider(!showColumnWidthSlider)}
+          <Tooltip
+            title='12 hour time'
+            placement='top'
+            slotProps={{
+              tooltip: {
+                style: { marginBottom: 4 },
+              },
+            }}
           >
-            <Typography fontSize={16}>AM/PM</Typography>
-          </IconButton>
-        </Tooltip> */}
+            <ToggleButton className='timeline-control' value={false}>
+              12AM
+            </ToggleButton>
+          </Tooltip>
+          <Tooltip
+            title='24 hour time'
+            placement='top'
+            slotProps={{
+              tooltip: {
+                style: { marginBottom: 4 },
+              },
+            }}
+          >
+            <ToggleButton className='timeline-control' value={true}>
+              00:00
+            </ToggleButton>
+          </Tooltip>
+        </ToggleButtonGroup>
       </Stack>
 
       <div

--- a/web/src/repo/TimelineCard.tsx
+++ b/web/src/repo/TimelineCard.tsx
@@ -4,7 +4,6 @@ import { RadioButtonChecked, WarningAmber } from '@mui/icons-material';
 import { Avatar, Tooltip, Typography } from '@mui/material';
 import { Link } from 'react-router-dom';
 
-import { PIXELS_PER_HOUR } from './RepoTimeline';
 import { IconText } from '../components/IconText';
 import { RoleplayEvent } from '../model/RoleplayEvent';
 import { RoleplayStatus } from '../model/RoleplayProject';
@@ -44,8 +43,9 @@ export const TimelineCard = (props: TimelineCardProps) => {
     otherLinks,
   } = project;
 
-  const marginLeft = PIXELS_PER_HOUR * (event.startDate.getMinutes() / 60);
-  const marginRight = PIXELS_PER_HOUR * (1 - event.endDate.getMinutes() / 60);
+  const totalGridMinutes = (gridColumnEnd - gridColumnStart) * 60;
+  const marginLeft = `${(event.startDate.getMinutes() / totalGridMinutes) * 100}%`;
+  const marginRight = `${((60 - event.endDate.getMinutes()) / totalGridMinutes) * 100}%`;
   return (
     <div
       key={projectId + startDate}
@@ -62,7 +62,7 @@ export const TimelineCard = (props: TimelineCardProps) => {
           marginLeft,
           marginRight,
           mask: event.isDefaultEnd
-            ? `linear-gradient(to left, #0000 5px, #0001 20px, #000f ${2 * PIXELS_PER_HOUR}px)`
+            ? `linear-gradient(to left, #0000 5px, #0001 20px, #000f 50%)`
             : 'none',
         }}
       >

--- a/web/src/util/Math.ts
+++ b/web/src/util/Math.ts
@@ -1,0 +1,3 @@
+export const lerp = (a: number, b: number, alpha: number) => {
+  return a + alpha * (b - a);
+};


### PR DESCRIPTION
Added timeline controls:
- Jump to current time
  - Scrolls to current time marker
- Jump to date
  - Opens a calendar view and scrolls to selected date
- Column width
  - Opens a slider to adjust column width between 50-100px
- Military time toggle
  - Swaps the time headers between 12 hour and 24 hour time
 
Also included:
- Fixed backward loading drag issues
- Added view-based culling (huge performance boost)

In conclusion: `setCurrentDate(new Date())` is incredibly overpowered