### PR TITLE
Adjust client-side times to DST if observed by client locale

### DIFF
--- a/web/src/model/RoleplayProject.ts
+++ b/web/src/model/RoleplayProject.ts
@@ -61,18 +61,26 @@ const adjustDst = (date: Date) => {
   if (observesDst(date) && isDst(date)) {
     date.setHours(date.getHours() - 1);
   }
-
-  return date;
 };
 
 export const mapProject = (project: RoleplayProject): RoleplayProject => {
   const scheduleType = project.schedule?.type;
   const runtimes =
-    project.schedule?.runtimes?.map<Runtime>((runtime) => ({
-      ...runtime,
-      start: adjustDst(new Date(runtime.start)),
-      end: runtime.end && adjustDst(new Date(runtime.end)),
-    })) ?? [];
+    project.schedule?.runtimes?.map<Runtime>((runtime) => {
+      const start = new Date(runtime.start);
+      if (scheduleType === ScheduleType.Periodic) {
+        adjustDst(start);
+      }
+      const end = runtime.end && new Date(runtime.end);
+      if (end && scheduleType === ScheduleType.Periodic) {
+        adjustDst(end);
+      }
+      return {
+        ...runtime,
+        start,
+        end,
+      };
+    }) ?? [];
   runtimes.sort((a, b) => {
     const { start: startA } = a;
     const { start: startB } = b;

--- a/web/src/model/RoleplayProject.ts
+++ b/web/src/model/RoleplayProject.ts
@@ -1,5 +1,6 @@
 import { RoleplaySchedule, Runtime, ScheduleType } from './RoleplayScheduling';
 import { User } from './User';
+import { isDst, observesDst } from '../util/Time';
 
 export enum RoleplayStatus {
   Active = 'Active',
@@ -56,13 +57,21 @@ export interface RoleplayProject {
 // mute
 // desktop
 
+const adjustDst = (date: Date) => {
+  if (observesDst(date) && isDst(date)) {
+    date.setHours(date.getHours() - 1);
+  }
+
+  return date;
+};
+
 export const mapProject = (project: RoleplayProject): RoleplayProject => {
   const scheduleType = project.schedule?.type;
   const runtimes =
     project.schedule?.runtimes?.map<Runtime>((runtime) => ({
       ...runtime,
-      start: new Date(runtime.start),
-      end: runtime.end && new Date(runtime.end),
+      start: adjustDst(new Date(runtime.start)),
+      end: runtime.end && adjustDst(new Date(runtime.end)),
     })) ?? [];
   runtimes.sort((a, b) => {
     const { start: startA } = a;

--- a/web/src/repo/RoleplayProjectPage.tsx
+++ b/web/src/repo/RoleplayProjectPage.tsx
@@ -47,6 +47,7 @@ import {
   RoleplayStatus,
   mapProject,
 } from '../model/RoleplayProject';
+import { ScheduleType } from '../model/RoleplayScheduling';
 import { PageData, queryServer } from '../model/ServerResponse';
 import { postUpdate, Update } from '../model/Update';
 import { UserRole } from '../model/User';
@@ -343,7 +344,7 @@ export const RoleplayProjectPage = (props: RoleplayProjectPageProps) => {
 
     const savedProject = { ...project };
     const adjustDst = observesDst(new Date()) && isDst(new Date());
-    if (adjustDst) {
+    if (adjustDst && project.schedule?.type === ScheduleType.Periodic) {
       savedProject.schedule?.runtimes?.forEach((runtime) => {
         runtime.start.setHours(runtime.start.getHours() + 1);
         runtime.end?.setHours(runtime.end.getHours() + 1);

--- a/web/src/repo/RoleplayProjectPage.tsx
+++ b/web/src/repo/RoleplayProjectPage.tsx
@@ -1,3 +1,4 @@
+import './RoleplayProjectPage.css';
 import {
   ArrowDropDown,
   Cancel,
@@ -49,8 +50,7 @@ import {
 import { PageData, queryServer } from '../model/ServerResponse';
 import { postUpdate, Update } from '../model/Update';
 import { UserRole } from '../model/User';
-
-import './RoleplayProjectPage.css';
+import { isDst, observesDst } from '../util/Time';
 
 /**
  * Pixel width under which to stack updates under roleplay info.
@@ -341,10 +341,19 @@ export const RoleplayProjectPage = (props: RoleplayProjectPageProps) => {
         .catch(createErrorSnackbar);
     }
 
+    const savedProject = { ...project };
+    const adjustDst = observesDst(new Date()) && isDst(new Date());
+    if (adjustDst) {
+      savedProject.schedule?.runtimes?.forEach((runtime) => {
+        runtime.start.setHours(runtime.start.getHours() + 1);
+        runtime.end?.setHours(runtime.end.getHours() + 1);
+      });
+    }
+
     if (isNew) {
       queryServer<string>('/projects', {
         method: 'POST',
-        body: project,
+        body: savedProject,
         isJson: true,
         useAuth: true,
       })

--- a/web/src/util/Time.tsx
+++ b/web/src/util/Time.tsx
@@ -2,6 +2,22 @@ import dayjs from 'dayjs';
 
 import { ScheduleRegion } from '../model/RoleplayScheduling';
 
+const stdTimezoneOffset = (date: Date) => {
+  const jan = new Date(date.getFullYear(), 0, 1);
+  const jul = new Date(date.getFullYear(), 6, 1);
+  return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
+};
+
+export const observesDst = (date: Date) => {
+  const jan = new Date(date.getFullYear(), 0, 1);
+  const jul = new Date(date.getFullYear(), 6, 1);
+  return jan.getTimezoneOffset() != jul.getTimezoneOffset();
+};
+
+export const isDst = (date: Date) => {
+  return date.getTimezoneOffset() < stdTimezoneOffset(date);
+};
+
 export const getLocale = () => {
   return navigator.languages ? navigator.languages[0] : navigator.language;
 };


### PR DESCRIPTION
The impetus here is: we kick down the time by an hour if it's saved in DST, then kick it back up an hour when presented on the client locale when it's in DST. This is only done for periodic schedules.

Note: this assumes *all* periodic schedules adjust for DST. This will service more people than the lack thereof, but it may be worth adding a control for this down the line.